### PR TITLE
[Feature vector] Create Feature vector API failed when Feature tag includes dot

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitleView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitleView.js
@@ -72,7 +72,7 @@ const FeatureSetsPanelTitleView = ({
             }
             type="text"
             value={data.version}
-            validationRules={getValidationRules('common.tag')}
+            validationRules={getValidationRules('feature.sets.tag')}
             wrapperClassName="version"
           />
         </div>

--- a/src/utils/validationService.js
+++ b/src/utils/validationService.js
@@ -246,6 +246,13 @@ const validationRules = {
     ]
   },
   feature: {
+    sets: {
+      tag: [
+        generateRule.validCharacters('a-z A-Z 0-9 - _'),
+        generateRule.beginEndWith('a-z A-Z 0-9'),
+        generateRule.length({ max: 56 })
+      ]
+    },
     vector: {
       name: [
         generateRule.validCharacters('a-z A-Z 0-9 - _ .'),


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-1691

Before: 
![image](https://user-images.githubusercontent.com/78905712/160547302-2f389e49-f276-433b-9ed0-e5ed7a6113f0.png)

After:
![image](https://user-images.githubusercontent.com/78905712/160547237-06c8b55c-15f9-4f33-9599-1fa2a213ef41.png)
