### PR TITLE
Fix [Jobs and workflows] job name not passed as a request parameter after click on specific job

### DIFF
--- a/src/actions/jobs.js
+++ b/src/actions/jobs.js
@@ -221,8 +221,10 @@ const jobsActions = {
       ...config,
       params: {
         ...config?.params,
-        name: jobName,
-        ...generateRequestParams(filters)
+        ...generateRequestParams({
+          ...filters,
+          name: jobName
+        })
       }
     }
 


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6742